### PR TITLE
Fallback to default language if field is empty

### DIFF
--- a/linguo/models.py
+++ b/linguo/models.py
@@ -107,7 +107,7 @@ class MultilingualModelBase(ModelBase):
             translated_attr = getattr(self_reference, attrname)
             
             # If empty, fall back to default language
-            if (translated_attr is u'' and
+            if (not translated_attr and
                     self_reference._language != settings.LANGUAGE_CODE):
                 current_language = self_reference._language
                 self_reference.translate(settings.LANGUAGE_CODE)


### PR DESCRIPTION
Hello,

I use linguo in a project where not all products are translated - and for these products I have to display the original text.

I modified `MultilingualModel`'s `getter` to fallback to the default language so instead of doing:

``` python
# views.py
product = Product.objects.get(pk=1)
product_translated = product.get_translation('en')

# template.html
Name: {{ product_translated.name|default:product.name }}
Description: {{ product_translated.description|default:product.description }}
```

I can do:

``` python
# views.py
product = Product.objects.get(pk=1).activate('en')

# template.html
Name: {{ product.name }}
Description: {{ product.description }}
```

There are a few reasons why I think this is good:
1. More consistent with django's built in translation method (falls back to default if it's not translated)
2. Less code to write (at least for my case, but I'd think most other use cases are similar)

Obviously, this change breaks a few tests that expect non translated fields to return an empty string. But I'll update those if you plan on merging this in.

If you're worried about breaking existing projects, we can also make this behavior optional through a flag in settings.py (LINGUO_FALLBACK).

Let me know what you think!

Regards,
Selwin
