### PR TITLE
Use django's db_column if set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,54 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/

--- a/linguo/models.py
+++ b/linguo/models.py
@@ -85,6 +85,10 @@ class MultilingualModelBase(ModelBase):
                 lang_fieldname = get_real_field_name(field, lang_code)
                 lang_field.name = lang_fieldname
 
+                if attrs[field].db_column:
+                    lang_field.db_column = get_real_field_name(attrs[field].db_column, lang_code)
+                    print lang_field.db_column
+
                 if lang_field.verbose_name is not None:
                     # This is to extract the original value that was passed into ugettext_lazy
                     # We do this so that we avoid evaluating the lazy object.

--- a/linguo/tests/models.py
+++ b/linguo/tests/models.py
@@ -130,6 +130,12 @@ class Lan(MultilingualModel):
         translate = ('name',)
 
 
+class DbColumnNameModel(MultilingualModel):
+    name = models.CharField(max_length=50, db_column="prefixed_name")
+
+    class Meta:
+        translate = ('name',)
+
 """
 class AbstractCar(models.Model):
     name = models.CharField(max_length=255, verbose_name=_('name'), default=None)

--- a/linguo/tests/tests.py
+++ b/linguo/tests/tests.py
@@ -1421,6 +1421,26 @@ class TestMultilingualForm(LinguoTests):
         self.assertEqual(form.initial['description'], 'Hello')
         self.assertEqual(form.initial['description_fr'], 'French Hello')
 
+class TestFeaturesThatShouldveBeenPresent(LinguoTests):
+
+    def testDbColumnNameHandling(self):
+        """
+        Test that a modle with db_column set on a translatable field
+        properly works.
+        """
+        instance = DbColumnNameModel(name="english name")
+        instance.translate(language='fr', name="french name")
+        instance.save()
+
+        translation.activate('fr')
+        m = DbColumnNameModel.objects.get(id=instance.id)
+        self.assertEqual(m.name, 'french name')
+
+        translation.activate('en')
+        m = DbColumnNameModel.objects.get(id=instance.id)
+        self.assertEqual(m.name, 'english name')
+
+
 
 class TestsForUnupportedFeatures(object):  # LinguoTests):
 

--- a/linguo/tests/tests.py
+++ b/linguo/tests/tests.py
@@ -1421,7 +1421,7 @@ class TestMultilingualForm(LinguoTests):
         self.assertEqual(form.initial['description'], 'Hello')
         self.assertEqual(form.initial['description_fr'], 'French Hello')
 
-class TestFeaturesThatShouldveBeenPresent(LinguoTests):
+class TestDjangoORMFieldSettings(LinguoTests):
 
     def testDbColumnNameHandling(self):
         """


### PR DESCRIPTION
Django lets you set `db_column` on model fields. This is especially useful when using a table that was created for legacy code and doesn't match the ORMs default column names. This modifies the behavior of `django-linguo` to use the specified `db_column` if it is set, enabling the use of `django-linguo` with a wider range of Models/tables.
