### PR TITLE
add field_object.related.parent_model fix for Django 1.8.

### DIFF
--- a/linguo/managers.py
+++ b/linguo/managers.py
@@ -48,8 +48,12 @@ def get_fields_to_translatable_models(model):
     for field_name in model._meta.get_all_field_names():
         field_object, modelclass, direct, m2m = model._meta.get_field_by_name(field_name)
         if direct and isinstance(field_object, RelatedField):
-            if issubclass(field_object.related.parent_model, MultilingualModel):
-                results.append((field_name, field_object.related.parent_model))
+            try:
+                parent_model = field_object.related.parent_model
+            except AttributeError:
+                parent_model = field_object.related.model
+            if issubclass(parent_model, MultilingualModel):
+                results.append((field_name, parent_model))
     return results
 
 


### PR DESCRIPTION
Django 1.8 changed the field_object.related.parent_model interface, add a try statement to use the the new interface if catch AttributeError. All tests passed under Django 1.8.1.
