### PR TITLE
Fix bug preventing related fields without parent model from loading

### DIFF
--- a/linguo/managers.py
+++ b/linguo/managers.py
@@ -48,8 +48,8 @@ def get_fields_to_translatable_models(model):
     for field_name in model._meta.get_all_field_names():
         field_object, modelclass, direct, m2m = model._meta.get_field_by_name(field_name)
         if direct and isinstance(field_object, RelatedField):
-            if issubclass(field_object.related.parent_model, MultilingualModel):
-                results.append((field_name, field_object.related.parent_model))
+            if issubclass(field_object.related.model, MultilingualModel):
+                results.append((field_name, field_object.related.model))
     return results
 
 


### PR DESCRIPTION
Not all `field_object.related` have `parent_model` attribute, (Multilinguals do, but other may or may not have) but is_subclass method works with the `model` attribute just as well, without crashing on fields related to models without a `parent_model`. I am not quite sure but this may be related to django 1.8.
